### PR TITLE
Change other into debian

### DIFF
--- a/xrdp_base/Dockerfile
+++ b/xrdp_base/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
     make && \
     make install && \
     xrdp-keygen xrdp auto && \
-    cp instfiles/pam.d/xrdp-sesman.other /etc/pam.d/xrdp-sesman && \
+    cp instfiles/pam.d/xrdp-sesman.debian /etc/pam.d/xrdp-sesman && \
     cd /opt/xrdp/xorg/X11R7.6 && \
     ./buildx.sh /opt/X11rdp && \
     ln -s /opt/X11rdp/bin/X11rdp /usr/local/bin/X11rdp && \


### PR DESCRIPTION
At line 30 https://github.com/neutrinolabs/xrdp/tree/devel/instfiles/pam.d/xrdp-sesman.other does not exists anymore and is superseded by https://github.com/neutrinolabs/xrdp/tree/devel/instfiles/pam.d/xrdp-sesman.debian